### PR TITLE
Correcting Python2 vs Python3 versioning issue

### DIFF
--- a/make_asym.c
+++ b/make_asym.c
@@ -126,7 +126,14 @@ PyInit_make_asym(void)
 #else
 #define INITERROR return
 
-void
+#if PY_MAJOR_VERSION >= 3
+#define NUMPY_IMPORT_ARRAY_RETURN_TYPE int
+#else
+#define NUMPY_IMPORT_ARRAY_RETURN_TYPE void
+
+#endif
+
+NUMPY_IMPORT_ARRAY_RETURN_TYPE
 initmake_asym(void)
 {
   import_array();


### PR DESCRIPTION
Added `#define` lines to control for Python3 vs Python2 specific syntax

`initmake_asym` flags an error while compiling this routine using the standard approached "python setup.py install". 

``` bash
make_asym.c:133:3: error: void function 'initmake_asym' should not return a value [-Wreturn-type]
  return Py_InitModule("make_asym", make_asym_methods);
  ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning and 1 error generated.
error: command 'gcc' failed with exit status 1
```

I found https://github.com/tensorflow/tensorflow/pull/764/files

Looking through that pull request led me to know the `initmake_asym` error above was a python versioning issue.  Specifically, Python3 requires the init module to return an int, while Python2 requires the init module to return a void.  By adding the `#define` lines, we are able to control for this depending on the version itself.

Therefore `make_asym.c` required statements for including #if PY_MAJOR_VERSION >= 3 
- Resolves compile issues with Python2, but controlling the init function declaration return
- Adds 5 lines to the entire code
