### PR TITLE
Fix import error from "asym.py"

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,1 @@
-from asym.py import *
+from asym import *

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,1 @@
-from asym import *
+from asym.py import *

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,43 @@
 
 from distutils.core import setup, Extension
 
+### Start Creating Direcotry in site-packages ###
+from os         import path, mkdir, getcwd
+from subprocess import Popen
+from site       import getsitepackages
+
+CurrentDir  = getcwd() + '/'
+PackageDir  = getsitepackages()[0]
+dirExists   = path.exists(PackageDir)
+
+if not dirExists:
+    print PackageDir + ' DOES NOT EXIST'
+
+InstallDir  = PackageDir + '/least_asymmetry/'
+dirExists   = path.exists(InstallDir)
+
+print''
+print InstallDir
+print''
+
+try:
+    if not dirExists:
+        print '\n\n Directory DOES NOT Exist. Creating NOW \n\n'
+        mkdir(InstallDir)
+    elif len(argv) > 1 and argv[1] == 'overwrite':
+        print '\n\n Directory Exists Deleting before Over Writing Symbolic Links \n\n'
+        Popen(["/bin/bash", "-c", "rm -rf " + InstallDir])
+        print "rm -rf " + InstallDir
+        print '\n\n Re-Creating Directory NOW \n' + InstallDir + '\n\n'
+        mkdir(InstallDir)
+    else:
+        print '\n\n Directory Exists.  If you want to overwrite all files, type "python install.py overwrite"\n\n'
+except:
+    raise Exception, "\n\nSomething went wrong: you probably don't have permissions to make \n" + InstallDir + '\n\n'
+
+### End Creating Direcotry in site-packages ###
+
+
 cpp_args = ['-std=c++11', '-stdlib=libc++', '-mmacosx-version-min=10.7']
 
 ext_modules = [
@@ -24,3 +61,8 @@ setup(
     description='A module for calculating centers though least asymmetry',
     ext_modules=ext_modules,
 )
+
+### Start moving asym.py to site-packages ###
+Popen(['/bin/cp', CurrentDir + 'asym.py'    , InstallDir])
+Popen(['/bin/cp', CurrentDir + '__init__.py', InstallDir])
+### End moving asym.py to site-packages ###


### PR DESCRIPTION
When importing the last asymmetry package, the **init**.py script simply imports everything from asym.py.  But in the current version, the import command includes the ".py" at the end of the filename, which flags an ImportError when using the packge.

changes: 

Original **init**.py line 1: from asym.py import *
New  **init**.py line 1: from asym import *

The fix above on line 1 of the **init**.py script simply removes the ".py" at the end of the import statement to make importing the package as simple as the example claims from the README file / github home.
